### PR TITLE
Install etcdutl as well if it exists.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,3 +46,18 @@
   with_items:
     - etcd{{ etcd_exe_suffix | default("") }}
     - etcdctl{{ etcd_exe_suffix | default("") }}
+
+- name: check if this version has an etcdutl
+  become: true
+  stat:
+    path: '{{ etcd_install_dir }}/etcdutl{{ etcd_exe_suffix | default("") }}'
+  register: etcd_has_etcdutl
+
+  - name: linking etcdutil from {{ etcd_install_dir }} to {{ etcd_install_subdir }}
+  become: true
+  become_user: root
+  file:
+    src: '{{ etcd_install_subdir }}/etcdutl{{ etcd_exe_suffix | default("") }}'
+    dest: '{{ etcd_install_dir }}/etcdutl{{ etcd_exe_suffix | default("") }}'
+    state: link
+  when: etcd_has_etcdutl.stat.exists


### PR DESCRIPTION
Modern etcd includes an extra utility called etcdutl which can be helpful during certain admin events. Install it if it exists.